### PR TITLE
Fix formatting

### DIFF
--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -14,13 +14,13 @@ enum JinjaError: Error, LocalizedError {
     case todo(String)
     case syntaxNotSupported(String)
 
-  var errorDescription: String? {
-    switch self {
-      case .syntax(let message): return "Syntax error: \(message)"
-      case .parser(let message): return "Parser error: \(message)"
-      case .runtime(let message): return "Runtime error: \(message)"
-      case .todo(let message): return "Todo error: \(message)"
-      case .syntaxNotSupported(let string): return "Syntax not supported: \(string)"
+    var errorDescription: String? {
+        switch self {
+        case .syntax(let message): return "Syntax error: \(message)"
+        case .parser(let message): return "Parser error: \(message)"
+        case .runtime(let message): return "Runtime error: \(message)"
+        case .todo(let message): return "Todo error: \(message)"
+        case .syntaxNotSupported(let string): return "Syntax not supported: \(string)"
+        }
     }
-  }
 }

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -193,12 +193,14 @@ func parse(tokens: [Token]) throws -> Program {
             var filter = try parsePrimaryExpression()
             if let boolLiteralFilter = filter as? BoolLiteral {
                 filter = Identifier(value: String(boolLiteralFilter.value))
-            } else if filter is NullLiteral {
+            }
+            else if filter is NullLiteral {
                 filter = Identifier(value: "none")
             }
             if let test = filter as? Identifier {
                 operand = TestExpression(operand: operand as! Expression, negate: negate, test: test)
-            } else {
+            }
+            else {
                 throw JinjaError.syntax("Expected identifier for the test")
             }
         }

--- a/Sources/Runtime.swift
+++ b/Sources/Runtime.swift
@@ -296,7 +296,7 @@ struct Interpreter {
                         throw JinjaError.runtime("Cannot unpack non-iterable type: \(type(of:current))")
                     }
                 default:
-                        throw JinjaError.syntaxNotSupported(String(describing: node.loopvar))
+                    throw JinjaError.syntaxNotSupported(String(describing: node.loopvar))
                 }
 
                 let evaluated = try self.evaluateBlock(statements: node.body, environment: scope)
@@ -429,18 +429,22 @@ struct Interpreter {
 
         if left is StringValue, right is ObjectValue {
             switch node.operation.value {
-                case "in":
-                    if let leftString = (left as? StringValue)?.value,
-                       let rightObject = right as? ObjectValue {
-                        return BooleanValue(value: rightObject.value.keys.contains(leftString))
-                    }
-                case "not in":
-                    if let leftString = (left as? StringValue)?.value,
-                       let rightObject = right as? ObjectValue {
-                        return BooleanValue(value: !rightObject.value.keys.contains(leftString))
-                    }
-                default:
-                    throw JinjaError.runtime("Unsupported operation '\(node.operation.value)' between StringValue and ObjectValue")
+            case "in":
+                if let leftString = (left as? StringValue)?.value,
+                    let rightObject = right as? ObjectValue
+                {
+                    return BooleanValue(value: rightObject.value.keys.contains(leftString))
+                }
+            case "not in":
+                if let leftString = (left as? StringValue)?.value,
+                    let rightObject = right as? ObjectValue
+                {
+                    return BooleanValue(value: !rightObject.value.keys.contains(leftString))
+                }
+            default:
+                throw JinjaError.runtime(
+                    "Unsupported operation '\(node.operation.value)' between StringValue and ObjectValue"
+                )
             }
         }
 
@@ -683,7 +687,8 @@ struct Interpreter {
         if let testFunction = environment.tests[node.test.value] {
             let result = try testFunction(operand)
             return BooleanValue(value: node.negate ? !result : result)
-        } else {
+        }
+        else {
             throw JinjaError.runtime("Unknown test: \(node.test.value)")
         }
     }
@@ -718,11 +723,13 @@ struct Interpreter {
             case let statement as FilterExpression:
                 return try self.evaluateFilterExpression(node: statement, environment: environment)
             case let statement as TestExpression:
-              return try self.evaluateTestExpression(node: statement, environment: environment)
+                return try self.evaluateTestExpression(node: statement, environment: environment)
             case is NullLiteral:
                 return NullValue()
             default:
-                throw JinjaError.runtime("Unknown node type: \(type(of:statement)), statement: \(String(describing: statement))")
+                throw JinjaError.runtime(
+                    "Unknown node type: \(type(of:statement)), statement: \(String(describing: statement))"
+                )
             }
         }
         else {


### PR DESCRIPTION
I see that we already have a .swift-format file, so I ran swift-format, and there are some changes, perhaps because I didn't run it before submitting a previous PR. Maybe we can configure a GitHub action so that all PRs are checked before merging. Once this is merged, I'll revise my previous PR to remove changes due to formatting differences.

Would you mind if we remove `lineBreakBeforeControlFlowKeywords`? I find the code more difficult to read with this setting enabled, and I think most Swift code does not use this rule, but it's also a matter of personal taste.