### PR TITLE
Handle Qwen 3 chat template

### DIFF
--- a/Sources/Runtime.swift
+++ b/Sources/Runtime.swift
@@ -189,6 +189,30 @@ struct StringValue: RuntimeValue {
             "lstrip": FunctionValue(value: { _, _ in
                 StringValue(value: value.replacingOccurrences(of: "^\\s+", with: "", options: .regularExpression))
             }),
+            "split": FunctionValue(value: { args, _ in
+                guard let separatorArg = args.first as? StringValue else {
+                    // Default split by whitespace if no separator is provided or if it's not a string
+                    // (This mimics Python's str.split() behavior loosely)
+                    let components = value.split(whereSeparator: { $0.isWhitespace })
+                    return ArrayValue(value: components.map { StringValue(value: String($0)) })
+                }
+                let separator = separatorArg.value
+                // TODO: Add optional maxsplit argument handling if needed
+                let components = value.components(separatedBy: separator)
+                return ArrayValue(value: components.map { StringValue(value: $0) })
+            }),
+            "startswith": FunctionValue(value: { args, _ in
+                guard let prefixArg = args.first as? StringValue else {
+                    throw JinjaError.runtime("startswith requires a string prefix argument")
+                }
+                return BooleanValue(value: value.hasPrefix(prefixArg.value))
+            }),
+            "endswith": FunctionValue(value: { args, _ in
+                guard let suffixArg = args.first as? StringValue else {
+                    throw JinjaError.runtime("endswith requires a string suffix argument")
+                }
+                return BooleanValue(value: value.hasSuffix(suffixArg.value))
+            }),
         ]
     }
 

--- a/Tests/Templates/ChatTemplateTests.swift
+++ b/Tests/Templates/ChatTemplateTests.swift
@@ -636,4 +636,27 @@ final class ChatTemplateTests: XCTestCase {
             """
         XCTAssertEqual(result, target)
     }
+
+    func testQwen3() throws {
+        let chatTemplate = """
+            {%- if tools %}\n    {{- '<|im_start|>system\\n' }}\n    {%- if messages[0].role == 'system' %}\n        {{- messages[0].content + '\\n\\n' }}\n    {%- endif %}\n    {{- \"# Tools\\n\\nYou may call one or more functions to assist with the user query.\\n\\nYou are provided with function signatures within <tools></tools> XML tags:\\n<tools>\" }}\n    {%- for tool in tools %}\n        {{- \"\\n\" }}\n        {{- tool | tojson }}\n    {%- endfor %}\n    {{- \"\\n</tools>\\n\\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\\n<tool_call>\\n{\\\"name\\\": <function-name>, \\\"arguments\\\": <args-json-object>}\\n</tool_call><|im_end|>\\n\" }}\n{%- else %}\n    {%- if messages[0].role == 'system' %}\n        {{- '<|im_start|>system\\n' + messages[0].content + '<|im_end|>\\n' }}\n    {%- endif %}\n{%- endif %}\n{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}\n{%- for message in messages[::-1] %}\n    {%- set index = (messages|length - 1) - loop.index0 %}\n    {%- if ns.multi_step_tool and message.role == \"user\" and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}\n        {%- set ns.multi_step_tool = false %}\n        {%- set ns.last_query_index = index %}\n    {%- endif %}\n{%- endfor %}\n{%- for message in messages %}\n    {%- if (message.role == \"user\") or (message.role == \"system\" and not loop.first) %}\n        {{- '<|im_start|>' + message.role + '\\n' + message.content + '<|im_end|>' + '\\n' }}\n    {%- elif message.role == \"assistant\" %}\n        {%- set content = message.content %}\n        {%- set reasoning_content = '' %}\n        {%- if message.reasoning_content is defined and message.reasoning_content is not none %}\n            {%- set reasoning_content = message.reasoning_content %}\n        {%- else %}\n            {%- if '</think>' in message.content %}\n                {%- set content = message.content.split('</think>')[-1].lstrip('\\n') %}\n                {%- set reasoning_content = message.content.split('</think>')[0].rstrip('\\n').split('<think>')[-1].lstrip('\\n') %}\n            {%- endif %}\n        {%- endif %}\n        {%- if loop.index0 > ns.last_query_index %}\n            {%- if loop.last or (not loop.last and reasoning_content) %}\n                {{- '<|im_start|>' + message.role + '\\n<think>\\n' + reasoning_content.strip('\\n') + '\\n</think>\\n\\n' + content.lstrip('\\n') }}\n            {%- else %}\n                {{- '<|im_start|>' + message.role + '\\n' + content }}\n            {%- endif %}\n        {%- else %}\n            {{- '<|im_start|>' + message.role + '\\n' + content }}\n        {%- endif %}\n        {%- if message.tool_calls %}\n            {%- for tool_call in message.tool_calls %}\n                {%- if (loop.first and content) or (not loop.first) %}\n                    {{- '\\n' }}\n                {%- endif %}\n                {%- if tool_call.function %}\n                    {%- set tool_call = tool_call.function %}\n                {%- endif %}\n                {{- '<tool_call>\\n{\"name\": \"' }}\n                {{- tool_call.name }}\n                {{- '\", \"arguments\": ' }}\n                {%- if tool_call.arguments is string %}\n                    {{- tool_call.arguments }}\n                {%- else %}\n                    {{- tool_call.arguments | tojson }}\n                {%- endif %}\n                {{- '}\\n</tool_call>' }}\n            {%- endfor %}\n        {%- endif %}\n        {{- '<|im_end|>\\n' }}\n    {%- elif message.role == \"tool\" %}\n        {%- if loop.first or (messages[loop.index0 - 1].role != \"tool\") %}\n            {{- '<|im_start|>user' }}\n        {%- endif %}\n        {{- '\\n<tool_response>\\n' }}\n        {{- message.content }}\n        {{- '\\n</tool_response>' }}\n        {%- if loop.last or (messages[loop.index0 + 1].role != \"tool\") %}\n            {{- '<|im_end|>\\n' }}\n        {%- endif %}\n    {%- endif %}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- '<|im_start|>assistant\\n' }}\n    {%- if enable_thinking is defined and enable_thinking is false %}\n        {{- '<think>\\n\\n</think>\\n\\n' }}\n    {%- endif %}\n{%- endif %}
+            """
+        let userMessage = [
+            "role": "user",
+            "content": "Why is the sky blue?",
+        ]
+        let template = try Template(chatTemplate)
+        let result = try template.render([
+            "messages": [userMessage],
+            "bos_token": "<|begin_of_text|>",
+            "add_generation_prompt": true,
+        ])
+        let target = """
+            <|im_start|>user
+            Why is the sky blue?<|im_end|>
+            <|im_start|>assistant
+
+            """
+        XCTAssertEqual(result, target)
+    }
 }


### PR DESCRIPTION
This PR adds methods used in the Qwen 3 chat template, which were previously missing from this library.

@johnmai-dev, to keep the commit history of this repo clean, I suggest using the squash on merge strategy (you can configure it in the repo's settings on GitHub). Currently there's a separate merge commit for each merged PR. 