### PR TITLE
Possible Memory Leak When Using Filters

### DIFF
--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -153,7 +153,7 @@ class Environment {
         },
         // TODO: Implement "sameas"
         // TODO: Implement "escaped"
-        "in": { args in
+        "in": {[unowned self] args in
             guard let seq = args[1] as? ArrayValue else {
                 throw JinjaError.runtime("in test requires a sequence")
             }
@@ -161,76 +161,76 @@ class Environment {
                 self.doEqualTo([args[0], item])
             }
         },
-        "==": { args in self.doEqualTo(args) },
-        "eq": { args in self.doEqualTo(args) },
-        "equalto": { args in self.doEqualTo(args) },
-        "!=": { args in
+        "==": {[unowned self] args in self.doEqualTo(args) },
+        "eq": {[unowned self] args in self.doEqualTo(args) },
+        "equalto": {[unowned self] args in self.doEqualTo(args) },
+        "!=": {[unowned self] args in
             guard args.count == 2 else {
                 throw JinjaError.runtime("!= test requires two arguments")
             }
             return !self.doEqualTo(args)
         },
-        "ne": { args in
+        "ne": {[unowned self] args in
             guard args.count == 2 else {
                 throw JinjaError.runtime("ne test requires two arguments")
             }
             return !self.doEqualTo(args)
         },
-        ">": { args in
+        ">": {[unowned self] args in
             guard args.count == 2 else {
                 throw JinjaError.runtime("> test requires two arguments")
             }
             return try self.doGreaterThan(args)
         },
-        "gt": { args in
+        "gt": {[unowned self] args in
             guard args.count == 2 else {
                 throw JinjaError.runtime("gt test requires two arguments")
             }
             return try self.doGreaterThan(args)
         },
-        "greaterthan": { args in
+        "greaterthan": {[unowned self] args in
             guard args.count == 2 else {
                 throw JinjaError.runtime("greaterthan test requires two arguments")
             }
             return try self.doGreaterThan(args)
         },
-        ">=": { args in
+        ">=": {[unowned self] args in
             guard args.count == 2 else {
                 throw JinjaError.runtime(">= test requires two arguments")
             }
             return try self.doGreaterThanOrEqual(args)
         },
-        "ge": { args in
+        "ge": {[unowned self] args in
             guard args.count == 2 else {
                 throw JinjaError.runtime("ge test requires two arguments")
             }
             return try self.doGreaterThanOrEqual(args)
         },
-        "<": { args in
+        "<": {[unowned self] args in
             guard args.count == 2 else {
                 throw JinjaError.runtime("< test requires two arguments")
             }
             return try self.doLessThan(args)
         },
-        "lt": { args in
+        "lt": {[unowned self] args in
             guard args.count == 2 else {
                 throw JinjaError.runtime("lt test requires two arguments")
             }
             return try self.doLessThan(args)
         },
-        "lessthan": { args in
+        "lessthan": {[unowned self] args in
             guard args.count == 2 else {
                 throw JinjaError.runtime("lessthan test requires two arguments")
             }
             return try self.doLessThan(args)
         },
-        "<=": { args in
+        "<=": {[unowned self] args in
             guard args.count == 2 else {
                 throw JinjaError.runtime("<= test requires two arguments")
             }
             return try self.doLessThanOrEqual(args)
         },
-        "le": { args in
+        "le": {[unowned self] args in
             guard args.count == 2 else {
                 throw JinjaError.runtime("le test requires two arguments")
             }
@@ -354,8 +354,8 @@ class Environment {
             }
             throw JinjaError.runtime("Cannot count value of type \(type(of: value))")
         },
-        "d": { args, env in try self.doDefault(args, env) },
-        "default": { args, env in try self.doDefault(args, env) },
+        "d": {[unowned self] args, env in try self.doDefault(args, env) },
+        "default": {[unowned self] args, env in try self.doDefault(args, env) },
         "dictsort": { args, env in
             guard let dict = args[0] as? ObjectValue else {
                 throw JinjaError.runtime("dictsort filter requires a dictionary")
@@ -396,8 +396,8 @@ class Environment {
                 }
             )
         },
-        "e": { args, env in try self.doEscape(args, env) },
-        "escape": { args, env in try self.doEscape(args, env) },
+        "e": {[unowned self] args, env in try self.doEscape(args, env) },
+        "escape": {[unowned self] args, env in try self.doEscape(args, env) },
         "filesizeformat": { args, env in
             guard let value = args[0] as? NumericValue else {
                 throw JinjaError.runtime("filesizeformat filter requires a numeric value")
@@ -488,7 +488,7 @@ class Environment {
             }
             return StringValue(value: result)
         },
-        "groupby": { args, env in
+        "groupby": {[unowned self] args, env in
             guard let arrayValue = args[0] as? ArrayValue else {
                 throw JinjaError.runtime("groupby filter requires an array")
             }

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -36,12 +36,8 @@ public struct Template {
         }
 
         let interpreter = Interpreter(env: env)
+       
         let result = try interpreter.run(program: self.parsed) as! StringValue
-        
-        // Clear to fix memory leak issue
-        env.variables.removeAll()
-        env.filters.removeAll()
-        env.tests.removeAll()
         
         return result.value
     }

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -37,7 +37,12 @@ public struct Template {
 
         let interpreter = Interpreter(env: env)
         let result = try interpreter.run(program: self.parsed) as! StringValue
-
+        
+        // Clear to fix memory leak issue
+        env.variables.removeAll()
+        env.filters.removeAll()
+        env.tests.removeAll()
+        
         return result.value
     }
 }


### PR DESCRIPTION
In my template, I noticed a gradual increase in memory usage related to the use of filters. After setting up unit tests, I found that once the filters dictionary is initialized, it captures self, which prevents the associated Environment instance from being deinitialized properly.

Here’s a minimal test case that triggers the issue:

```swift
import XCTest
@testable import Jinja

final class MemoryLeaktests: XCTestCase {
    func testMemory() throws {
        let template = """
        {{ items|first}}
        """

        let context = [
            "items": [
                "a",
                "s",
                "a"
            ],
            "name": "Jinja"
        ] as [String : Any]

        let result = try Template(template).render(context)
        
        print(result)
    }
}
```